### PR TITLE
update graphql-tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "@types/node": "^14.14.16",
     "@types/ws": "^7.4.0",
     "graphql": "^15.5.1",
-    "graphql-tools": "^7.0.5",
     "husky": "^1.1.1",
     "jest": "^26.6.3",
     "lint-staged": "^7.3.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { mapSchema, getDirectives, MapperKind } from 'graphql-tools'
+import { mapSchema, getDirectives, MapperKind } from '@graphql-tools/utils'
 import { GraphQLSchema } from 'graphql'
 
 export default function privateDirective(directiveName: string) {
@@ -7,7 +7,7 @@ export default function privateDirective(directiveName: string) {
     privateDirectiveTransform: (schema: GraphQLSchema) =>
       mapSchema(schema, {
         [MapperKind.OBJECT_TYPE]: (type) => {
-          const typeDirectives = getDirectives(schema, type)
+          const typeDirectives: any = getDirectives(schema, type)
           if (typeDirectives.private) {
             return null
           } else {
@@ -15,7 +15,7 @@ export default function privateDirective(directiveName: string) {
           }
         },
         [MapperKind.OBJECT_FIELD]: (fieldConfig, fieldName, typeName) => {
-          const fieldDirectives = getDirectives(schema, fieldConfig)
+          const fieldDirectives: any = getDirectives(schema, fieldConfig)
           if (fieldDirectives.private) {
             return null
           } else {


### PR DESCRIPTION
Versions were updated to match current graphql-tools peer versions for graphql, and moved to org-level packages.